### PR TITLE
Optimises for O(n), fixes overlapping matches.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,27 @@
 module.exports = function count(hay, needle) {
     var matches = 0;
-    for (var i = 0; i < hay.length - needle.length + 1; i++) {
-        var fail = false;
-        for (var j = 0; j < needle.length; j++) {
-            if (hay[i + j] !== needle[j]) {
-                fail = true;
-                break
-            }
-        }
-        if (!fail) matches++
+    var i = 0;
+    var j = 0;
+    var length = hay.length;
+    var sublength = needle.length;
+
+    if (sublength === 0) {
+        return length;
     }
-    return matches
-}
+
+    while (i < length) {
+        if (hay[i + j] === needle[j]) {
+            j++;
+            if (j >= sublength) {
+                matches++;
+                i += j;
+                j = 0;
+            }
+        } else {
+            j = 0;
+            i++;
+        }
+    }
+
+    return matches;
+};

--- a/test.js
+++ b/test.js
@@ -3,6 +3,10 @@ var count = require('./');
 test('count-strings', function(t){
   t.equal(count('a b a', 'a'), 2);
   t.equal(count('foo bar foo bar', 'foo'), 2);
+  t.equal(count('ffoo fbar fqux', 'foo'), 1);
+  t.equal(count('abc', ''), 3);
+  t.equal(count('foo bar foo bar', 'qux'), 0);
+  t.equal(count('aaa', 'aa'), 1);
   t.end();
 });
 


### PR DESCRIPTION
Previously, for each index in the string of length N, the algorithm would look ahead M characters (where M is the length of the substring). This gave it an algorithmic complexity of O(nm), which could be slow with longer substrings (for N = 3000, and M = 30, for example, a total of 90000 lookups would be necessary).

The new implementation fuses lookup and iteration, such that we only look at the character at the point, and no further. This works by optimistically going forward in the string and comparing the current character against the current position in the substring. If we fail, we start over in the next position of the string. Otherwise, if we succeed all the way, we keep looking from after that point.

This also fixes #1.
